### PR TITLE
Add FTP File Transfer Instructions to Wiki (Get and Put options)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -109,6 +109,7 @@
 
 * [Password Spraying](ftp-protocol/password-spraying.md)
 * [🆕 File Listing, etc](ftp-protocol/file-listing-etc.md)
+* [🆕 File Upload & Download](ftp-protocol/get-and-put-files.md)
 
 ## RDP Protocol
 

--- a/ftp-protocol/get-and-put-files.md
+++ b/ftp-protocol/get-and-put-files.md
@@ -12,6 +12,7 @@ netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --ls [DIRECTORY]
 ```
 
 Example:
+
 ```
 netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --ls
 FTP         10.10.176.246   21     10.10.176.246    [*] Banner: (vsFTPd 3.0.3)
@@ -31,6 +32,7 @@ netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --get [FILE]
 ```
 
 Example:
+
 ```
 netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --get ftp_flag.thm
 FTP         10.10.176.246   21     10.10.176.246    [*] Banner: (vsFTPd 3.0.3)
@@ -47,6 +49,7 @@ netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --put [LOCAL_FILE] [REMOTE_
 ```
 
 Example:
+
 ```
  netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --put test.txt test.txt
 FTP         10.10.176.246   21     10.10.176.246    [*] Banner: (vsFTPd 3.0.3)

--- a/ftp-protocol/get-and-put-files.md
+++ b/ftp-protocol/get-and-put-files.md
@@ -1,6 +1,6 @@
 ---
 description: Instructions for using FTP commands to access and transfer files using NetExec.
-
+---
 # FTP File Access and Transfer
 
 ## List Files in a Directory

--- a/ftp-protocol/get-and-put-files.md
+++ b/ftp-protocol/get-and-put-files.md
@@ -14,6 +14,12 @@ netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --ls [DIRECTORY]
 Example:
 ```
 netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --ls
+FTP         10.10.176.246   21     10.10.176.246    [*] Banner: (vsFTPd 3.0.3)
+FTP         10.10.176.246   21     10.10.176.246    [+] frank:D2xc9CgD
+FTP         10.10.176.246   21     10.10.176.246    [*] Directory Listing
+FTP         10.10.176.246   21     10.10.176.246    drwx------   10 1001     1001         4096 Sep 15  2021 Maildir
+FTP         10.10.176.246   21     10.10.176.246    -rw-rw-r--    1 1001     1001         4006 Sep 15  2021 README.txt
+FTP         10.10.176.246   21     10.10.176.246    -rw-rw-r--    1 1001     1001           39 Sep 15  2021 ftp_flag.thm
 ```
 
 ## Download a File
@@ -27,11 +33,14 @@ netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --get [FILE]
 Example:
 ```
 netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --get ftp_flag.thm
+FTP         10.10.176.246   21     10.10.176.246    [*] Banner: (vsFTPd 3.0.3)
+FTP         10.10.176.246   21     10.10.176.246    [+] frank:D2xc9CgD
+FTP         10.10.176.246   21     10.10.176.246    [+] Downloaded: ftp_flag.thm
 ```
 
 ## Upload a File
 
-Upload a file to the FTP server.
+Upload a file to the FTP server providing you have relevant permissions
 
 ```
 netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --put [LOCAL_FILE] [REMOTE_FILE]
@@ -39,5 +48,8 @@ netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --put [LOCAL_FILE] [REMOTE_
 
 Example:
 ```
-netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --put localFile.txt remoteFile.txt
+ netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --put test.txt test.txt
+FTP         10.10.176.246   21     10.10.176.246    [*] Banner: (vsFTPd 3.0.3)
+FTP         10.10.176.246   21     10.10.176.246    [+] frank:D2xc9CgD
+FTP         10.10.176.246   21     10.10.176.246    [-] Failed to upload file. Response: (550 Permission denied.)
 ```

--- a/ftp-protocol/get-and-put-files.md
+++ b/ftp-protocol/get-and-put-files.md
@@ -1,0 +1,43 @@
+---
+description: Instructions for using FTP commands to access and transfer files using NetExec.
+
+# FTP File Access and Transfer
+
+## List Files in a Directory
+
+List files in a specific directory using FTP.
+
+```
+netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --ls [DIRECTORY]
+```
+
+Example:
+```
+netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --ls
+```
+
+## Download a File
+
+Download a file from the FTP server.
+
+```
+netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --get [FILE]
+```
+
+Example:
+```
+netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --get ftp_flag.thm
+```
+
+## Upload a File
+
+Upload a file to the FTP server.
+
+```
+netexec ftp [IP_ADDRESS] -u [USERNAME] -p [PASSWORD] --put [LOCAL_FILE] [REMOTE_FILE]
+```
+
+Example:
+```
+netexec ftp 10.10.176.246 -u frank -p D2xc9CgD --put localFile.txt remoteFile.txt
+```


### PR DESCRIPTION
This pull request adds a new section to the Wiki documentation, providing detailed instructions on using FTP commands for file access and transfer. The addition follows the existing documentation style and includes:

- Instructions for listing files in a directory, downloading, and uploading files using FTP.
- Command examples for each operation.
- A brief description at the beginning of the document for context.

The intent is to enhance the existing Wiki with FTP-related content, making it a more comprehensive resource for users needing guidance on various file transfer methods.

Please let me know if there are any changes or improvements you'd like me to make. I'm open to feedback and happy to collaborate to ensure the documentation is as helpful as possible for the community.

Best regards,
Leon Teale