### PR TITLE
Fix bad option name in spider_plus 

### DIFF
--- a/smb-protocol/spidering-shares.md
+++ b/smb-protocol/spidering-shares.md
@@ -26,8 +26,8 @@ nxc smb 10.10.10.10 -u 'user' -p 'pass' -M spider_plus
 
 ### Dumping All Files
 
-Using the option `-o READ_ONLY=false` all files will be copied on the host
+Using the option `-o DOWNLOAD_FLAG=True` all files will be copied on the host
 
 ```
-nxc smb 10.10.10.10 -u 'user' -p 'pass' -M spider_plus -o READ_ONLY=false
+nxc smb 10.10.10.10 -u 'user' -p 'pass' -M spider_plus -o DOWNLOAD_FLAG=True
 ```


### PR DESCRIPTION
The option name to dump file file from SMB shares have been changed from READ_ONLY to DOWNLOAD_FLAG
![image](https://github.com/Pennyw0rth/NetExec-Wiki/assets/76688185/9492a3e8-92bc-498e-b5e7-bbf3ed96f73b)
