### PR TITLE
Add ParrotSec to "Installation for Unix" section

### DIFF
--- a/getting-started/installation/installation-on-unix.md
+++ b/getting-started/installation/installation-on-unix.md
@@ -39,6 +39,13 @@ apt install netexec
 pacman -Syu netexec
 ```
 
+## Installation for ParrotSec 🦜
+
+```
+apt update
+apt install netexec
+```
+
 ## Availability on other Unix distributions :penguin:
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/netexec.svg)](https://repology.org/project/netexec/versions)


### PR DESCRIPTION
Hello everyone, I am one of the developers of ParrotSec. NetExec has been available in our distribution, and we will soon import the new version: https://gitlab.com/parrotsec/packages/netexec

We would love to see ParrotSec included in the NetExec documentation.

Thank you!