### PR TITLE
Changed name of wifi module

### DIFF
--- a/smb-protocol/obtaining-credentials/dump-wifi-password.md
+++ b/smb-protocol/obtaining-credentials/dump-wifi-password.md
@@ -7,5 +7,5 @@ You need at least local admin privilege on the remote target, use option **--loc
 {% endhint %}
 
 ```
-nxc smb <ip> -u user -p pass -M wireless
+nxc smb <ip> -u user -p pass -M wifi
 ```


### PR DESCRIPTION
I just noticed that the module for reading WLAN access data was incorrectly specified as “wireless” instead of “wifi”.