### PR TITLE
Add Documentation for Yandex Module

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -85,6 +85,7 @@
   * [🆕 Dump Notepad++](smb-protocol/obtaining-credentials/dump-notepad++.md)
   * [🆕 Dump Remote Desktop Credential Manager](smb-protocol/obtaining-credentials/dump-rdcman.md)
   * [🆕 Dump Event Log Creds(4688)](smb-protocol/obtaining-credentials/eventlog-creds.md)
+  * [🆕 Dump Yandex Credentials](smb-protocol/obtaining-credentials/dump-yandex-creds.md)
 * [Defeating LAPS](smb-protocol/defeating-laps.md)
 * [Checking for Spooler & WebDav](smb-protocol/spooler-webdav-running.md)
 * [Steal Microsoft Teams Cookies](smb-protocol/steal-microsoft-teams-cookies.md)

--- a/smb-protocol/obtaining-credentials/dump-yandex-creds.md
+++ b/smb-protocol/obtaining-credentials/dump-yandex-creds.md
@@ -1,0 +1,11 @@
+# Dump Yandex Browser Credentials
+
+Extract all saved passwords from the Yandex browser for every user on the system.
+
+{% hint style="warning" %}
+You need at least local admin privilege on the remote target
+{% endhint %}
+
+```bash
+nxc smb <ip> -u user -p pass -M yandex
+```


### PR DESCRIPTION
Adding documentation to accompany NetExec PR: https://github.com/Pennyw0rth/NetExec/pull/814

Implemented a module to dump yandex credentials from the target system.