### PR TITLE
Fix broken hackthebox links

### DIFF
--- a/ldap-protocol/asreproast.md
+++ b/ldap-protocol/asreproast.md
@@ -56,7 +56,7 @@ hashcat -m18200 output.txt wordlist
 
 Forest machine is a good example to test **ASREPRoast** with NetExec
 
-{% embed url="https://www.hackthebox.eu/home/machines/profile/212" %}
+{% embed url="https://www.hackthebox.com/machines/forest" %}
 
 ### Ressources
 

--- a/ldap-protocol/kerberoasting.md
+++ b/ldap-protocol/kerberoasting.md
@@ -36,7 +36,7 @@ hashcat -m13100 output.txt wordlist.txt
 
 Active machine is a good example to test **Kerberoasting** with NetExec
 
-{% embed url="https://www.hackthebox.eu/home/machines/profile/148" %}
+{% embed url="https://www.hackthebox.com/machines/active" %}
 
 ### Useful ressources:
 

--- a/mssql-protocol/mssql-command.md
+++ b/mssql-protocol/mssql-command.md
@@ -33,4 +33,4 @@ When playing with MSSQL, you can use the tool [MSDAT ](https://github.com/quenti
 
 Mantis machine is a good example to test **MSSQL** procotol with NetExec
 
-{% embed url="https://www.hackthebox.eu/home/machines/profile/98" %}
+{% embed url="https://www.hackthebox.com/machines/mantis" %}

--- a/smb-protocol/enumeration/enumerate-guest-logon.md
+++ b/smb-protocol/enumeration/enumerate-guest-logon.md
@@ -25,4 +25,4 @@ Note that if the domain guest account is available you will be able to use to la
 
 Nest machine is a good example of **guest logon** with NetExec
 
-{% embed url="https://www.hackthebox.eu/home/machines/profile/225" %}
+{% embed url="https://www.hackthebox.com/machines/nest" %}

--- a/smb-protocol/enumeration/enumerate-null-sessions.md
+++ b/smb-protocol/enumeration/enumerate-null-sessions.md
@@ -29,8 +29,8 @@ user:[zoro] rid:[0x46f]
 
 Forest or Monteverde machines are good examples to test **null session** authentication with NetExec
 
-{% embed url="https://www.hackthebox.eu/home/machines/profile/212" %}
+{% embed url="https://www.hackthebox.com/machines/forest" %}
 
-{% embed url="https://www.hackthebox.eu/home/machines/profile/223" %}
+{% embed url="https://www.hackthebox.com/machines/monteverde" %}
 
 

--- a/winrm-protocol/authentication.md
+++ b/winrm-protocol/authentication.md
@@ -32,4 +32,4 @@ WINRM       192.168.255.131 5985   192.168.255.131  [+] GOLD\user:password (Pwn3
 
 Monteverde machine is a good example to test **WinRM** procotol with NetExec
 
-{% embed url="https://www.hackthebox.eu/home/machines/profile/223" %}
+{% embed url="https://www.hackthebox.com/machines/monteverde" %}


### PR DESCRIPTION
While adding the example machine for https://github.com/Pennyw0rth/NetExec-Wiki/pull/60 , I noticed that the existing links to hackthebox machines were broken. This PR brings them back up to date.