### PR TITLE
Docs: case when aardwolf fails to build

### DIFF
--- a/getting-started/installation/installation-on-unix.md
+++ b/getting-started/installation/installation-on-unix.md
@@ -39,6 +39,8 @@ pipx reinstall netexec      # Force download the latest commits from github
 
 If pip fails to build aardwolf you need to [install rust](https://www.rust-lang.org/tools/install). Don't forget to reload your shell so rust is added to your PATH!
 
+If pip still fails with an error saying that _the configured Python interpreter version (3.x) is newer than PyO3's maximum supported version (3.y)"_, then set environment variable `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` and retry installing.
+
 ## Installation for Kali :dragon\_face:
 
 ```bash


### PR DESCRIPTION
```
$ pipx install git+https://github.com/Pennyw0rth/NetExec
⣽ installing netexec from spec 'git+https://github.com/Pennyw0rth/NetExec'
Fatal error from pip prevented installation. Full pip output in file:
    /home/user/.local/state/pipx/log/cmd_2026-06-12_14.07.12_pip_errors.log

pip failed to build package:
    aardwolf

Some possibly relevant errors from pip install:
    error: subprocess-exited-with-error
    error: failed to run custom build command for `pyo3-ffi v0.23.5`
    error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
    error: `cargo rustc --lib --message-format=json-render-diagnostics --manifest-path aardwolf/utils/rlers/Cargo.toml --release -v --features pyo3/extension-module --crate-type cdylib` failed
 with code 101
    error: failed-wheel-build-for-install

Error installing netexec from spec 'git+https://github.com/Pennyw0rth/NetExec'.
```

I guess this can happen again in the future:

> configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)

Setting `export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` (or simply `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 pipx install ...`) seems to work